### PR TITLE
[FIXED] Missing dependency boto3 in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='duckietown-challenges',
           'ruamel.yaml',
           'docker',
           'psutil',
+          'boto3==1.9.14'
       ],
 
       tests_require=[


### PR DESCRIPTION
The `boto3` dependency was missing in `setup.py`. Installation with `pip install -e .` fails.